### PR TITLE
Refactor into pure interface & virtual-like operator() access

### DIFF
--- a/source/HyperBuffer.hpp
+++ b/source/HyperBuffer.hpp
@@ -24,7 +24,6 @@ class HyperBufferPreAllocFlat : public IHyperBuffer<T, N, HyperBufferPreAllocFla
     using typename IHyperBuffer<T, N, HyperBufferPreAllocFlat>::pointer_type;
     using typename IHyperBuffer<T, N, HyperBufferPreAllocFlat>::const_pointer_type;
     using typename IHyperBuffer<T, N, HyperBufferPreAllocFlat>::size_type;
-    using IHyperBuffer<T, N, HyperBufferPreAllocFlat>::STL;
 
 public:
     /** Constructor that takes the extents of the dimensions as a variable argument list */
@@ -32,7 +31,7 @@ public:
     HyperBufferPreAllocFlat(T* preAllocatedDataFlat, I... i) :
         m_bufferGeometry(i...),
         m_externalData(preAllocatedDataFlat),
-        m_pointers(STL(m_bufferGeometry.getRequiredPointerArraySize()))
+        m_pointers(m_bufferGeometry.getRequiredPointerArraySize())
     {
         m_bufferGeometry.hookupPointerArrayToData(m_externalData, m_pointers.data());
     }
@@ -76,15 +75,14 @@ class HyperBuffer : public IHyperBuffer<T, N, HyperBuffer<T, N>>
     using typename IHyperBuffer<T, N, HyperBuffer<T, N>>::size_type;
     using typename IHyperBuffer<T, N, HyperBuffer<T, N>>::pointer_type;
     using typename IHyperBuffer<T, N, HyperBuffer<T, N>>::const_pointer_type;
-    using IHyperBuffer<T, N, HyperBuffer<T, N>>::STL;
 
 public:
     /** Constructor that takes the extents of the dimensions as a variable argument list */
     template<typename... I>
     explicit HyperBuffer(I... i) :
         m_bufferGeometry(i...),
-        m_data(STL(m_bufferGeometry.getRequiredDataArraySize())),
-        m_pointers(STL(m_bufferGeometry.getRequiredPointerArraySize()))
+        m_data(m_bufferGeometry.getRequiredDataArraySize()),
+        m_pointers(m_bufferGeometry.getRequiredPointerArraySize())
     {
         m_bufferGeometry.hookupPointerArrayToData(m_data.data(), m_pointers.data());
     }

--- a/source/HyperBuffer.hpp
+++ b/source/HyperBuffer.hpp
@@ -17,8 +17,6 @@
 namespace slb
 {
 
-template<typename T, int N> class HyperBuffer; // forward-declare
-
 // MARK: - HyperBufferPreAllocFlat - manages existing 1D data
 template<typename T, int N>
 class HyperBufferPreAllocFlat : public HyperBufferBase<T, N, HyperBufferPreAllocFlat<T, N>>

--- a/source/HyperBuffer.hpp
+++ b/source/HyperBuffer.hpp
@@ -17,20 +17,22 @@
 namespace slb
 {
 
+template<typename T, int N> class HyperBuffer; // forward-declare
+
 // MARK: - HyperBufferPreAllocFlat - manages existing 1D data
 template<typename T, int N>
-class HyperBufferPreAllocFlat : public HyperBufferBase<T, N>
+class HyperBufferPreAllocFlat : public HyperBufferBase<T, N, HyperBufferPreAllocFlat<T, N>>
 {
-    using pointer_type = typename HyperBufferBase<T, N>::pointer_type;
-    using const_pointer_type = typename HyperBufferBase<T, N>::const_pointer_type;
-    using size_type = typename HyperBufferBase<T, N>::size_type;
-    using HyperBufferBase<T, N>::STL;
+    using pointer_type = typename HyperBufferBase<T, N, HyperBufferPreAllocFlat>::pointer_type;
+    using const_pointer_type = typename HyperBufferBase<T, N, HyperBufferPreAllocFlat>::const_pointer_type;
+    using size_type = typename HyperBufferBase<T, N, HyperBufferPreAllocFlat>::size_type;
+    using HyperBufferBase<T, N, HyperBufferPreAllocFlat>::STL;
 
 public:
     /** Constructor that takes the extents of the dimensions as a variable argument list */
     template<typename... I>
     HyperBufferPreAllocFlat(T* preAllocatedDataFlat, I... i) :
-        HyperBufferBase<T, N>(i...),
+        HyperBufferBase<T, N, HyperBufferPreAllocFlat<T, N>>(i...),
         m_bufferGeometry(i...),
         m_externalData(preAllocatedDataFlat),
         m_pointers(STL(m_bufferGeometry.getRequiredPointerArraySize()))
@@ -38,21 +40,20 @@ public:
         m_bufferGeometry.hookupPointerArrayToData(m_externalData, m_pointers.data());
     }
     
-    // MARK: - common functions not in base class (they differ in return type)
-    
+private:
     // MARK: operator()
-    FOR_N1 const T& operator() (size_type i) const { return getDataPointer_N1()[i]; }
+    // MARK: - common functions not in base class (they differ in return type)
     FOR_N1       T& operator() (size_type i)       { return getDataPointer_N1()[i]; }
-    
+    FOR_N1 const T& operator() (size_type i) const { return getDataPointer_N1()[i]; }
+
     /** Create sub-buffer by returning a N-1 view (no data ownership) (recursive, multiple arguments) */
     FOR_Nx_V decltype(auto) operator() (size_type dn, I... i) const { return createSubBufferView(dn).operator()(i...); }
     FOR_Nx_V decltype(auto) operator() (size_type dn, I... i)       { return createSubBufferView(dn).operator()(i...); }
 
     /** Create sub-buffer by returning a N-1 view (no data ownership) (single argument) */
-    FOR_Nx decltype(auto) operator() (size_type dn) const { return createSubBufferView(dn); }
-    FOR_Nx decltype(auto) operator() (size_type dn)       { return createSubBufferView(dn); }
+    FOR_Nx const HyperBufferPreAllocFlat<T, N-1> operator() (size_type dn) const { return createSubBufferView(dn); }
+    FOR_Nx       HyperBufferPreAllocFlat<T, N-1> operator() (size_type dn)       { return createSubBufferView(dn); }
 
-private:
     /** Build a const N-1 HyperBuffer view to this Hyperbuffer's data */
     const HyperBufferPreAllocFlat<T, N-1> createSubBufferView(size_type index) const
     {
@@ -73,6 +74,10 @@ private:
     T* getDataPointer_N1()                       override { return *m_pointers.data(); }
 
 private:
+    friend HyperBufferBase<T, N, HyperBufferPreAllocFlat<T, N>>;
+    friend HyperBufferPreAllocFlat<T, N+1>;
+    friend HyperBuffer<T, N+1>;
+
     BufferGeometry<N> m_bufferGeometry;
     T* m_externalData;
     std::vector<T*> m_pointers;
@@ -81,18 +86,18 @@ private:
 // ====================================================================================================================
 // MARK: - HyperBuffer - owns its own data
 template<typename T, int N>
-class HyperBuffer : public HyperBufferBase<T, N>
+class HyperBuffer : public HyperBufferBase<T, N, HyperBuffer<T, N>>
 {
-    using pointer_type = typename HyperBufferBase<T, N>::pointer_type;
-    using const_pointer_type = typename HyperBufferBase<T, N>::const_pointer_type;
-    using size_type = typename HyperBufferBase<T, N>::size_type;
-    using HyperBufferBase<T, N>::STL;
+    using pointer_type = typename HyperBufferBase<T, N, HyperBuffer<T, N>>::pointer_type;
+    using const_pointer_type = typename HyperBufferBase<T, N, HyperBuffer<T, N>>::const_pointer_type;
+    using size_type = typename HyperBufferBase<T, N, HyperBuffer<T, N>>::size_type;
+    using HyperBufferBase<T, N, HyperBuffer<T, N>>::STL;
 
 public:
     /** Constructor that takes the extents of the dimensions as a variable argument list */
     template<typename... I>
     explicit HyperBuffer(I... i) :
-        HyperBufferBase<T, N>(i...),
+        HyperBufferBase<T, N,HyperBuffer<T, N>>(i...),
         m_bufferGeometry(i...),
         m_data(STL(m_bufferGeometry.getRequiredDataArraySize())),
         m_pointers(STL(m_bufferGeometry.getRequiredPointerArraySize()))
@@ -102,19 +107,19 @@ public:
     
     // MARK: - common functions not in base class (they differ in return type)
 
+private:
     // MARK:  operator()
     FOR_N1 const T& operator() (size_type i) const { return getDataPointer_N1()[i]; }
     FOR_N1       T& operator() (size_type i)       { return getDataPointer_N1()[i]; }
-   
+
     /** Create sub-buffer by returning a N-1 view (no data ownership) in the form of a HyperBufferPreAllocFlat (recursive, multiple arguments) */
     FOR_Nx_V decltype(auto) operator() (size_type dn, I... i) const { return createSubBufferView(dn).operator()(i...); }
     FOR_Nx_V decltype(auto) operator() (size_type dn, I... i)       { return createSubBufferView(dn).operator()(i...); }
     
     /** Create sub-buffer by returning a N-1 view (no data ownership) in the form of a HyperBufferPreAllocFlat (single argument) */
-    FOR_Nx decltype(auto) operator() (size_type dn) const { return createSubBufferView(dn); }
-    FOR_Nx decltype(auto) operator() (size_type dn)       { return createSubBufferView(dn); }
-    
-private:
+    FOR_Nx const HyperBufferPreAllocFlat<T, N-1> operator() (size_type dn) const { return createSubBufferView(dn); }
+    FOR_Nx       HyperBufferPreAllocFlat<T, N-1> operator() (size_type dn)       { return createSubBufferView(dn); }
+
     /** Build a (non-owning) N-1 HyperBuffer view to this Hyperbuffer's data */
     const HyperBufferPreAllocFlat<T, N-1> createSubBufferView(size_type index) const
     {
@@ -137,6 +142,8 @@ private:
     T* getDataPointer_N1()                       override { return *m_pointers.data(); }
 
 private:
+    friend HyperBufferBase<T, N, HyperBuffer<T, N>>;
+
     BufferGeometry<N> m_bufferGeometry;
     
     /** All the data (innermost dimension) is stored in a 1D structure and access with offsets to simulate multi-dimensionality */
@@ -146,38 +153,36 @@ private:
     std::vector<T*> m_pointers;
 };
 
-
 // ====================================================================================================================
 // MARK: - HyperBufferPreAlloc - manages existing multi-dimensional data (wrapper)
 template<typename T, int N>
-class HyperBufferPreAlloc : public HyperBufferBase<T, N>
+class HyperBufferPreAlloc : public HyperBufferBase<T, N, HyperBufferPreAlloc<T, N>>
 {
-    using pointer_type = typename HyperBufferBase<T, N>::pointer_type;
-    using const_pointer_type = typename HyperBufferBase<T, N>::const_pointer_type;
-    using size_type = typename HyperBufferBase<T, N>::size_type;
+    using pointer_type = typename HyperBufferBase<T, N, HyperBufferPreAlloc<T, N>>::pointer_type;
+    using const_pointer_type = typename HyperBufferBase<T, N, HyperBufferPreAlloc<T, N>>::const_pointer_type;
+    using size_type = typename HyperBufferBase<T, N, HyperBufferPreAlloc<T, N>>::size_type;
 
 public:
     /** Constructor that takes the extents of the dimensions as a variable argument list */
     template<typename... I>
     HyperBufferPreAlloc(pointer_type preAllocatedData, I... i) :
-        HyperBufferBase<T, N>(i...),
+        HyperBufferBase<T, N, HyperBufferPreAlloc<T, N>>(i...),
         m_externalData(preAllocatedData) {}
     
+private:
     // MARK: - common functions not in base class (they differ in return type)
-    
-    // MARK: operator()
     FOR_N1 const T& operator() (size_type i) const { return getDataPointer_N1()[i]; }
     FOR_N1       T& operator() (size_type i)       { return getDataPointer_N1()[i]; }
+    // MARK: operator()
     
     /** Create sub-buffer by returning a N-1 view (no data ownership) (recursive, multiple arguments) */
     FOR_Nx_V decltype(auto) operator() (size_type dn, I... i) const { return createSubBufferView(dn).operator()(i...); }
     FOR_Nx_V decltype(auto) operator() (size_type dn, I... i)       { return createSubBufferView(dn).operator()(i...); }
     
     /** Create sub-buffer by returning a N-1 view (no data ownership) (single argument) */
-    FOR_Nx decltype(auto) operator() (size_type dn) const { return createSubBufferView(dn); }
-    FOR_Nx decltype(auto) operator() (size_type dn)       { return createSubBufferView(dn); }
-    
-private:
+    FOR_Nx const HyperBufferPreAlloc<T, N-1> operator() (size_type dn) const { return createSubBufferView(dn); }
+    FOR_Nx       HyperBufferPreAlloc<T, N-1> operator() (size_type dn)       { return createSubBufferView(dn); }
+
     /** Build a const N-1 HyperBuffer view to this Hyperbuffer's data */
     const HyperBufferPreAlloc<T, N-1> createSubBufferView(size_type index) const
     {
@@ -197,6 +202,9 @@ private:
     T* getDataPointer_N1()                       override { return reinterpret_cast<T*>(m_externalData); }
     
 private:
+    friend HyperBufferBase<T, N, HyperBufferPreAlloc<T, N>>;
+    friend HyperBufferPreAlloc<T, N+1>;
+
     pointer_type m_externalData;
 };
 

--- a/source/HyperBuffer.hpp
+++ b/source/HyperBuffer.hpp
@@ -64,9 +64,7 @@ private:
     /** Build a N-1 HyperBuffer view to this Hyperbuffer's data */
     HyperBufferPreAllocFlat<T, N-1> createSubBufferView(size_type index)
     {
-        ASSERT(index < this->dim(0), "Index out of range");
-        int offset = m_bufferGeometry.getDataArrayOffsetForHighestOrderSubDim(index);
-        return HyperBufferPreAllocFlat<T, N-1>(&m_externalData[offset], StdArrayOperations::shaveOffFirstElement(this->dims()));
+        return std::as_const(*this).createSubBufferView(index);
     }
     
     const_pointer_type getDataPointer_Nx() const override { return reinterpret_cast<const_pointer_type>(m_pointers.data()); }
@@ -130,9 +128,7 @@ private:
     /** Build a (non-owning) N-1 HyperBuffer const view to this Hyperbuffer's data */
     HyperBufferPreAllocFlat<T, N-1> createSubBufferView(size_type index)
     {
-        ASSERT(index < this->dim(0), "Index out of range");
-        const int offset = m_bufferGeometry.getDataArrayOffsetForHighestOrderSubDim(index);
-        return HyperBufferPreAllocFlat<T, N-1>(&m_data[offset], StdArrayOperations::shaveOffFirstElement(this->dims()));
+        return std::as_const(*this).createSubBufferView(index);
     }
 
     const_pointer_type getDataPointer_Nx() const override { return reinterpret_cast<const_pointer_type>(m_pointers.data()); }
@@ -190,10 +186,9 @@ private:
     }
     
     /** Build a N-1 HyperBuffer view to this Hyperbuffer's data */
-    HyperBufferPreAlloc<T, N-1> createSubBufferView(const size_type index)
+    HyperBufferPreAlloc<T, N-1> createSubBufferView(size_type index)
     {
-        ASSERT(index < this->dim(0), "Index out of range");
-        return HyperBufferPreAlloc<T, N-1>(m_externalData[index], StdArrayOperations::shaveOffFirstElement(this->dims()));
+        return std::as_const(*this).createSubBufferView(index);
     }
 
     const_pointer_type getDataPointer_Nx() const override { return m_externalData; }

--- a/source/HyperBuffer.hpp
+++ b/source/HyperBuffer.hpp
@@ -23,9 +23,9 @@ template<typename T, int N> class HyperBuffer; // forward-declare
 template<typename T, int N>
 class HyperBufferPreAllocFlat : public HyperBufferBase<T, N, HyperBufferPreAllocFlat<T, N>>
 {
-    using pointer_type = typename HyperBufferBase<T, N, HyperBufferPreAllocFlat>::pointer_type;
-    using const_pointer_type = typename HyperBufferBase<T, N, HyperBufferPreAllocFlat>::const_pointer_type;
-    using size_type = typename HyperBufferBase<T, N, HyperBufferPreAllocFlat>::size_type;
+    using typename HyperBufferBase<T, N, HyperBufferPreAllocFlat>::pointer_type;
+    using typename HyperBufferBase<T, N, HyperBufferPreAllocFlat>::const_pointer_type;
+    using typename HyperBufferBase<T, N, HyperBufferPreAllocFlat>::size_type;
     using HyperBufferBase<T, N, HyperBufferPreAllocFlat>::STL;
 
 public:
@@ -62,8 +62,6 @@ private:
 
 private:
     friend HyperBufferBase<T, N, HyperBufferPreAllocFlat<T, N>>;
-    friend HyperBufferPreAllocFlat<T, N+1>;
-    friend HyperBuffer<T, N+1>;
 
     BufferGeometry<N> m_bufferGeometry;
     T* m_externalData;
@@ -75,9 +73,9 @@ private:
 template<typename T, int N>
 class HyperBuffer : public HyperBufferBase<T, N, HyperBuffer<T, N>>
 {
-    using pointer_type = typename HyperBufferBase<T, N, HyperBuffer<T, N>>::pointer_type;
-    using const_pointer_type = typename HyperBufferBase<T, N, HyperBuffer<T, N>>::const_pointer_type;
-    using size_type = typename HyperBufferBase<T, N, HyperBuffer<T, N>>::size_type;
+    using typename HyperBufferBase<T, N, HyperBuffer<T, N>>::size_type;
+    using typename HyperBufferBase<T, N, HyperBuffer<T, N>>::pointer_type;
+    using typename HyperBufferBase<T, N, HyperBuffer<T, N>>::const_pointer_type;
     using HyperBufferBase<T, N, HyperBuffer<T, N>>::STL;
 
 public:
@@ -100,7 +98,8 @@ private:
     {
         ASSERT(index < this->dim(0), "Index out of range");
         const int offset = m_bufferGeometry.getDataArrayOffsetForHighestOrderSubDim(index);
-        // NOTE: explicitly cast away the const-ness - need to provide a non-const pointer to HyperBufferPreAllocFlat ctor, even if we turn it into a const object
+        // NOTE: explicitly cast away the const-ness - need to provide a non-const pointer to the
+        // HyperBufferPreAllocFlat ctor, even if we turn it into a const object upon return
         T* subDimData = const_cast<T*>(&m_data[offset]);
         return HyperBufferPreAllocFlat<T, N-1>(subDimData, StdArrayOperations::shaveOffFirstElement(this->dims()));
     }
@@ -114,7 +113,7 @@ private:
     const_pointer_type getDataPointer_Nx() const override { return reinterpret_cast<const_pointer_type>(m_pointers.data()); }
     pointer_type getDataPointer_Nx()             override { return reinterpret_cast<pointer_type>(m_pointers.data()); }
     const T* getDataPointer_N1() const           override { return *m_pointers.data(); }
-    T* getDataPointer_N1()                       override { return *m_pointers.data(); }
+          T* getDataPointer_N1()                 override { return *m_pointers.data(); }
 
 private:
     friend HyperBufferBase<T, N, HyperBuffer<T, N>>;
@@ -133,9 +132,9 @@ private:
 template<typename T, int N>
 class HyperBufferPreAlloc : public HyperBufferBase<T, N, HyperBufferPreAlloc<T, N>>
 {
-    using pointer_type = typename HyperBufferBase<T, N, HyperBufferPreAlloc<T, N>>::pointer_type;
-    using const_pointer_type = typename HyperBufferBase<T, N, HyperBufferPreAlloc<T, N>>::const_pointer_type;
-    using size_type = typename HyperBufferBase<T, N, HyperBufferPreAlloc<T, N>>::size_type;
+    using typename HyperBufferBase<T, N, HyperBufferPreAlloc<T, N>>::size_type;
+    using typename HyperBufferBase<T, N, HyperBufferPreAlloc<T, N>>::pointer_type;
+    using typename HyperBufferBase<T, N, HyperBufferPreAlloc<T, N>>::const_pointer_type;
 
 public:
     /** Constructor that takes the extents of the dimensions as a variable argument list */
@@ -165,7 +164,6 @@ private:
     
 private:
     friend HyperBufferBase<T, N, HyperBufferPreAlloc<T, N>>;
-    friend HyperBufferPreAlloc<T, N+1>;
 
     pointer_type m_externalData;
 };

--- a/source/HyperBuffer.hpp
+++ b/source/HyperBuffer.hpp
@@ -41,19 +41,6 @@ public:
     }
     
 private:
-    // MARK: operator()
-    // MARK: - common functions not in base class (they differ in return type)
-    FOR_N1       T& operator() (size_type i)       { return getDataPointer_N1()[i]; }
-    FOR_N1 const T& operator() (size_type i) const { return getDataPointer_N1()[i]; }
-
-    /** Create sub-buffer by returning a N-1 view (no data ownership) (recursive, multiple arguments) */
-    FOR_Nx_V decltype(auto) operator() (size_type dn, I... i) const { return createSubBufferView(dn).operator()(i...); }
-    FOR_Nx_V decltype(auto) operator() (size_type dn, I... i)       { return createSubBufferView(dn).operator()(i...); }
-
-    /** Create sub-buffer by returning a N-1 view (no data ownership) (single argument) */
-    FOR_Nx const HyperBufferPreAllocFlat<T, N-1> operator() (size_type dn) const { return createSubBufferView(dn); }
-    FOR_Nx       HyperBufferPreAllocFlat<T, N-1> operator() (size_type dn)       { return createSubBufferView(dn); }
-
     /** Build a const N-1 HyperBuffer view to this Hyperbuffer's data */
     const HyperBufferPreAllocFlat<T, N-1> createSubBufferView(size_type index) const
     {
@@ -108,18 +95,6 @@ public:
     // MARK: - common functions not in base class (they differ in return type)
 
 private:
-    // MARK:  operator()
-    FOR_N1 const T& operator() (size_type i) const { return getDataPointer_N1()[i]; }
-    FOR_N1       T& operator() (size_type i)       { return getDataPointer_N1()[i]; }
-
-    /** Create sub-buffer by returning a N-1 view (no data ownership) in the form of a HyperBufferPreAllocFlat (recursive, multiple arguments) */
-    FOR_Nx_V decltype(auto) operator() (size_type dn, I... i) const { return createSubBufferView(dn).operator()(i...); }
-    FOR_Nx_V decltype(auto) operator() (size_type dn, I... i)       { return createSubBufferView(dn).operator()(i...); }
-    
-    /** Create sub-buffer by returning a N-1 view (no data ownership) in the form of a HyperBufferPreAllocFlat (single argument) */
-    FOR_Nx const HyperBufferPreAllocFlat<T, N-1> operator() (size_type dn) const { return createSubBufferView(dn); }
-    FOR_Nx       HyperBufferPreAllocFlat<T, N-1> operator() (size_type dn)       { return createSubBufferView(dn); }
-
     /** Build a (non-owning) N-1 HyperBuffer view to this Hyperbuffer's data */
     const HyperBufferPreAllocFlat<T, N-1> createSubBufferView(size_type index) const
     {
@@ -170,19 +145,6 @@ public:
         m_externalData(preAllocatedData) {}
     
 private:
-    // MARK: - common functions not in base class (they differ in return type)
-    FOR_N1 const T& operator() (size_type i) const { return getDataPointer_N1()[i]; }
-    FOR_N1       T& operator() (size_type i)       { return getDataPointer_N1()[i]; }
-    // MARK: operator()
-    
-    /** Create sub-buffer by returning a N-1 view (no data ownership) (recursive, multiple arguments) */
-    FOR_Nx_V decltype(auto) operator() (size_type dn, I... i) const { return createSubBufferView(dn).operator()(i...); }
-    FOR_Nx_V decltype(auto) operator() (size_type dn, I... i)       { return createSubBufferView(dn).operator()(i...); }
-    
-    /** Create sub-buffer by returning a N-1 view (no data ownership) (single argument) */
-    FOR_Nx const HyperBufferPreAlloc<T, N-1> operator() (size_type dn) const { return createSubBufferView(dn); }
-    FOR_Nx       HyperBufferPreAlloc<T, N-1> operator() (size_type dn)       { return createSubBufferView(dn); }
-
     /** Build a const N-1 HyperBuffer view to this Hyperbuffer's data */
     const HyperBufferPreAlloc<T, N-1> createSubBufferView(size_type index) const
     {

--- a/source/HyperBuffer.hpp
+++ b/source/HyperBuffer.hpp
@@ -54,9 +54,9 @@ private:
         return std::as_const(*this).createSubBufferView(index);
     }
     
-    const_pointer_type getDataPointer_Nx() const override { return reinterpret_cast<const_pointer_type>(m_pointers.data()); }
+    const_pointer_type  getDataPointer_Nx() const override { return reinterpret_cast<const_pointer_type>(m_pointers.data()); }
     pointer_type getDataPointer_Nx()             override { return reinterpret_cast<pointer_type>(m_pointers.data()); }
-    const T* getDataPointer_N1() const           override { return *m_pointers.data(); }
+    const T* getDataPointer_N1()           const override { return *m_pointers.data(); }
     T* getDataPointer_N1()                       override { return *m_pointers.data(); }
 
 private:
@@ -109,9 +109,9 @@ private:
     }
 
     const_pointer_type getDataPointer_Nx() const override { return reinterpret_cast<const_pointer_type>(m_pointers.data()); }
-    pointer_type getDataPointer_Nx()             override { return reinterpret_cast<pointer_type>(m_pointers.data()); }
-    const T* getDataPointer_N1() const           override { return *m_pointers.data(); }
-          T* getDataPointer_N1()                 override { return *m_pointers.data(); }
+          pointer_type getDataPointer_Nx()       override { return reinterpret_cast<pointer_type>(m_pointers.data()); }
+              const T* getDataPointer_N1() const override { return *m_pointers.data(); }
+                    T* getDataPointer_N1()       override { return *m_pointers.data(); }
 
 private:
     friend IHyperBuffer<T, N, HyperBuffer<T, N>>;
@@ -172,9 +172,9 @@ private:
     }
 
     const_pointer_type getDataPointer_Nx() const override { return m_externalData; }
-    pointer_type getDataPointer_Nx()             override { return m_externalData; }
-    const T* getDataPointer_N1() const           override { return reinterpret_cast<const T*>(m_externalData); }
-    T* getDataPointer_N1()                       override { return reinterpret_cast<T*>(m_externalData); }
+    pointer_type       getDataPointer_Nx()       override { return m_externalData; }
+              const T* getDataPointer_N1() const override { return reinterpret_cast<const T*>(m_externalData); }
+                    T* getDataPointer_N1()       override { return reinterpret_cast<T*>(m_externalData); }
     
 private:
     friend IHyperBuffer<T, N, HyperBufferPreAlloc<T, N>>;

--- a/source/HyperBuffer.hpp
+++ b/source/HyperBuffer.hpp
@@ -10,7 +10,7 @@
 #include <array>
 #include <vector>
 
-#include "HyperBufferBase.hpp"
+#include "IHyperBuffer.hpp"
 #include "TemplateUtils.hpp"
 #include "BufferGeometry.hpp"
 
@@ -19,12 +19,12 @@ namespace slb
 
 // MARK: - HyperBufferPreAllocFlat - manages existing 1D data
 template<typename T, int N>
-class HyperBufferPreAllocFlat : public HyperBufferBase<T, N, HyperBufferPreAllocFlat<T, N>>
+class HyperBufferPreAllocFlat : public IHyperBuffer<T, N, HyperBufferPreAllocFlat<T, N>>
 {
-    using typename HyperBufferBase<T, N, HyperBufferPreAllocFlat>::pointer_type;
-    using typename HyperBufferBase<T, N, HyperBufferPreAllocFlat>::const_pointer_type;
-    using typename HyperBufferBase<T, N, HyperBufferPreAllocFlat>::size_type;
-    using HyperBufferBase<T, N, HyperBufferPreAllocFlat>::STL;
+    using typename IHyperBuffer<T, N, HyperBufferPreAllocFlat>::pointer_type;
+    using typename IHyperBuffer<T, N, HyperBufferPreAllocFlat>::const_pointer_type;
+    using typename IHyperBuffer<T, N, HyperBufferPreAllocFlat>::size_type;
+    using IHyperBuffer<T, N, HyperBufferPreAllocFlat>::STL;
 
 public:
     /** Constructor that takes the extents of the dimensions as a variable argument list */
@@ -61,7 +61,7 @@ private:
     T* getDataPointer_N1()                       override { return *m_pointers.data(); }
 
 private:
-    friend HyperBufferBase<T, N, HyperBufferPreAllocFlat<T, N>>;
+    friend IHyperBuffer<T, N, HyperBufferPreAllocFlat<T, N>>;
 
     BufferGeometry<N> m_bufferGeometry;
     T* m_externalData;
@@ -71,12 +71,12 @@ private:
 // ====================================================================================================================
 // MARK: - HyperBuffer - owns its own data
 template<typename T, int N>
-class HyperBuffer : public HyperBufferBase<T, N, HyperBuffer<T, N>>
+class HyperBuffer : public IHyperBuffer<T, N, HyperBuffer<T, N>>
 {
-    using typename HyperBufferBase<T, N, HyperBuffer<T, N>>::size_type;
-    using typename HyperBufferBase<T, N, HyperBuffer<T, N>>::pointer_type;
-    using typename HyperBufferBase<T, N, HyperBuffer<T, N>>::const_pointer_type;
-    using HyperBufferBase<T, N, HyperBuffer<T, N>>::STL;
+    using typename IHyperBuffer<T, N, HyperBuffer<T, N>>::size_type;
+    using typename IHyperBuffer<T, N, HyperBuffer<T, N>>::pointer_type;
+    using typename IHyperBuffer<T, N, HyperBuffer<T, N>>::const_pointer_type;
+    using IHyperBuffer<T, N, HyperBuffer<T, N>>::STL;
 
 public:
     /** Constructor that takes the extents of the dimensions as a variable argument list */
@@ -116,7 +116,7 @@ private:
           T* getDataPointer_N1()                 override { return *m_pointers.data(); }
 
 private:
-    friend HyperBufferBase<T, N, HyperBuffer<T, N>>;
+    friend IHyperBuffer<T, N, HyperBuffer<T, N>>;
 
     BufferGeometry<N> m_bufferGeometry;
     
@@ -130,11 +130,11 @@ private:
 // ====================================================================================================================
 // MARK: - HyperBufferPreAlloc - manages existing multi-dimensional data (wrapper)
 template<typename T, int N>
-class HyperBufferPreAlloc : public HyperBufferBase<T, N, HyperBufferPreAlloc<T, N>>
+class HyperBufferPreAlloc : public IHyperBuffer<T, N, HyperBufferPreAlloc<T, N>>
 {
-    using typename HyperBufferBase<T, N, HyperBufferPreAlloc<T, N>>::size_type;
-    using typename HyperBufferBase<T, N, HyperBufferPreAlloc<T, N>>::pointer_type;
-    using typename HyperBufferBase<T, N, HyperBufferPreAlloc<T, N>>::const_pointer_type;
+    using typename IHyperBuffer<T, N, HyperBufferPreAlloc<T, N>>::size_type;
+    using typename IHyperBuffer<T, N, HyperBufferPreAlloc<T, N>>::pointer_type;
+    using typename IHyperBuffer<T, N, HyperBufferPreAlloc<T, N>>::const_pointer_type;
 
 public:
     /** Constructor that takes the extents of the dimensions as a variable argument list */
@@ -179,7 +179,7 @@ private:
     T* getDataPointer_N1()                       override { return reinterpret_cast<T*>(m_externalData); }
     
 private:
-    friend HyperBufferBase<T, N, HyperBufferPreAlloc<T, N>>;
+    friend IHyperBuffer<T, N, HyperBufferPreAlloc<T, N>>;
     
     std::array<int, N> m_dimensionExtents;
     pointer_type m_externalData;

--- a/source/HyperBufferBase.hpp
+++ b/source/HyperBufferBase.hpp
@@ -42,8 +42,8 @@ public:
     virtual ~HyperBufferBase() = default;
     
     // MARK: dimension extents
-    int dim(int i) const { ASSERT(i < N); return m_dimensionExtents[STL(i)]; }
-    const std::array<int, N>& dims() const { return m_dimensionExtents; }
+    virtual int dim(int i) const = 0;
+    virtual const std::array<int, N>& dims() const = 0;
 
     // NOTE: We cannot make these virtual functions because of the different return types required.
     // Overloading by return type is not allowed, so we need an enable_if construct for selective compilation
@@ -68,23 +68,6 @@ public:
     FOR_N1       T& at (size_type i)       { return getDataPointer_N1()[i]; }
 
 protected:
-    // MARK: constructors
-    /** Constructor that takes the extents of the dimensions as a variable argument list */
-    template<typename... I>
-    explicit HyperBufferBase(I... i) : m_dimensionExtents{static_cast<int>(i)...}
-    {
-        static_assert(sizeof...(I) == N, "Incorrect number of arguments");
-    }
-    
-    /** Constructor that takes the extents of the dimensions as a std::array */
-    explicit HyperBufferBase(const std::array<int, N>& dimensionExtents) : m_dimensionExtents{dimensionExtents} {}
-    
-    /** Constructor that takes the extents of the dimensions as a std::vector */
-    explicit HyperBufferBase(const std::vector<int>& dimensionExtents)
-    {
-        std::copy(dimensionExtents.begin(), dimensionExtents.end(), m_dimensionExtents.begin());
-    }
-
     // MARK: Virtual functions to be defined by derived classes
     virtual const_pointer_type getDataPointer_Nx() const = 0;
     virtual       pointer_type getDataPointer_Nx() = 0;
@@ -93,10 +76,6 @@ protected:
 
     // Helper to make interfacing with STL a bit more readable
     static constexpr stl_size_type STL(int i) { return static_cast<stl_size_type>(i); }
-
-private:
-    std::array<int, N> m_dimensionExtents; // only required as a member because of the dims functions
-
 };
 
 } // namespace slb

--- a/source/HyperBufferBase.hpp
+++ b/source/HyperBufferBase.hpp
@@ -60,10 +60,10 @@ public:
     FOR_N1 T& operator[] (size_type i) { return getDataPointer_N1()[i]; }
     
     // MARK: at() -- data/subbuffer access; returns Derived<T,N-1> instance or data
-    FOR_Nx_V decltype(auto) at (size_type dn, I... i) const { return static_cast<const Derived*>(this)->operator()(dn, i...); }
-    FOR_Nx_V decltype(auto) at (size_type dn, I... i)       { return static_cast<Derived*>(this)->operator()(dn, i...); }
-    FOR_Nx decltype(auto) at(size_type dn) const { return static_cast<const Derived*>(this)->operator()(dn); }
-    FOR_Nx decltype(auto) at (size_type dn)      { return static_cast<Derived*>(this)->operator()(dn); }
+    FOR_Nx_V decltype(auto) at (size_type dn, I... i) const { return static_cast<const Derived*>(this)->createSubBufferView(dn).at(i...); }
+    FOR_Nx_V decltype(auto) at (size_type dn, I... i)       { return static_cast<Derived*>(this)->createSubBufferView(dn).at(i...); }
+    FOR_Nx decltype(auto) at(size_type dn) const { return static_cast<const Derived*>(this)->createSubBufferView(dn); }
+    FOR_Nx decltype(auto) at (size_type dn)      { return static_cast<Derived*>(this)->createSubBufferView(dn); }
     FOR_N1 const T& at (size_type i) const { return getDataPointer_N1()[i]; }
     FOR_N1       T& at (size_type i)       { return getDataPointer_N1()[i]; }
 

--- a/source/HyperBufferBase.hpp
+++ b/source/HyperBufferBase.hpp
@@ -47,17 +47,17 @@ public:
 
     // NOTE: We cannot make these virtual functions because of the different return types required.
     // Overloading by return type is not allowed, so we need an enable_if construct for selective compilation
-    // MARK: data()
+    // MARK: data() -- raw pointer to beginning of underlying storage (pointers or data, depending on dimension)
     FOR_Nx const_pointer_type data() const { return getDataPointer_Nx(); }
-    FOR_Nx pointer_type data() { return getDataPointer_Nx(); }
+    FOR_Nx       pointer_type data()       { return getDataPointer_Nx(); }
     FOR_N1 const T* data() const { return getDataPointer_N1(); }
-    FOR_N1 T* data() { return getDataPointer_N1(); }
+    FOR_N1       T* data()       { return getDataPointer_N1(); }
     
     // MARK: operator[] -- raw data/pointer access; returns pointer N>1, reference for N=1
     FOR_Nx subdim_const_pointer_type operator[] (size_type i) const { return getDataPointer_Nx()[i]; }
-    FOR_Nx subdim_pointer_type operator[] (size_type i) { return getDataPointer_Nx()[i]; }
+    FOR_Nx       subdim_pointer_type operator[] (size_type i)       { return getDataPointer_Nx()[i]; }
     FOR_N1 const T& operator[] (size_type i) const { return getDataPointer_N1()[i]; }
-    FOR_N1 T& operator[] (size_type i) { return getDataPointer_N1()[i]; }
+    FOR_N1       T& operator[] (size_type i)       { return getDataPointer_N1()[i]; }
     
     // MARK: at() -- data/subbuffer access; returns Derived<T,N-1> instance or data
     FOR_Nx_V decltype(auto) at (size_type dn, I... i) const { return static_cast<const Derived*>(this)->createSubBufferView(dn).at(i...); }
@@ -87,9 +87,9 @@ protected:
 
     // MARK: Virtual functions to be defined by derived classes
     virtual const_pointer_type getDataPointer_Nx() const = 0;
-    virtual pointer_type getDataPointer_Nx() = 0;
+    virtual       pointer_type getDataPointer_Nx() = 0;
     virtual const T* getDataPointer_N1() const = 0;
-    virtual T* getDataPointer_N1() = 0;
+    virtual       T* getDataPointer_N1() = 0;
 
     // Helper to make interfacing with STL a bit more readable
     static constexpr stl_size_type STL(int i) { return static_cast<stl_size_type>(i); }

--- a/source/IHyperBuffer.hpp
+++ b/source/IHyperBuffer.hpp
@@ -77,10 +77,7 @@ protected:
     virtual       pointer_type getDataPointer_Nx() = 0;
     virtual const T* getDataPointer_N1() const = 0;
     virtual       T* getDataPointer_N1() = 0;
-
-    // Helper to make interfacing with STL a bit more readable
-    using stl_size_type = typename std::vector<T*>::size_type;
-    static constexpr stl_size_type STL(int i) { return static_cast<stl_size_type>(i); }
+    
 };
 
 } // namespace slb

--- a/source/IHyperBuffer.hpp
+++ b/source/IHyperBuffer.hpp
@@ -22,50 +22,54 @@ namespace slb
 {
 
 /**
- * This has to be a base and interface class at once, because we cannot apply std::enable_if to virtual functions and
- * we need the former for this to work in C++14.
+ *  Interface class for all variations of HyperBuffer.
+ *  The template parameters set the data type T (e.g. float) and the dimension N
+ *
+ *  - CRTP (Curiously Recurring Template Pattern) - aka 'static polymorphism' is used to access the
+ *    createSubBufferView() functions in the derived classes recursively.
+ *
+ *  - std::enable_if constructs are required to resolve for different dimensions (no overloaded return types possible)
+ *
+ *  - virtual functions cannot be used for data(), operator[] and at() because of said std::enable_if and
+ *    the deduced return types of decltype(auto) in the return of recursive functions (different for each recursion level)
+ *
  */
 template<typename T, int N, typename Derived=int> // CRTP with dummy default argument (Derived=int will never be used)
-class HyperBufferBase
+class IHyperBuffer
 {
 protected:
-    using size_type = int;
-    using pointer_type = typename add_pointers_to_type<T, N>::type;
-    using const_pointer_type = typename add_const_pointers_to_type<T, N>::type;
-    using subdim_pointer_type = typename remove_pointers_from_type<pointer_type, 1>::type;
+    using size_type                 = int;
+    using pointer_type              = typename add_pointers_to_type<T, N>::type;
+    using const_pointer_type        = typename add_const_pointers_to_type<T, N>::type;
+    using subdim_pointer_type       = typename remove_pointers_from_type<pointer_type, 1>::type;
     using subdim_const_pointer_type = typename remove_pointers_from_type<const_pointer_type, 1>::type;
 
-    // Helper to make interfacing with STL a bit more readable
-    using stl_size_type = typename std::vector<T*>::size_type;
-    
 public:
-    virtual ~HyperBufferBase() = default;
+    virtual ~IHyperBuffer() = default;
     
     // MARK: dimension extents
     virtual int dim(int i) const = 0;
     virtual const std::array<int, N>& dims() const = 0;
 
-    // NOTE: We cannot make these virtual functions because of the different return types required.
-    // Overloading by return type is not allowed, so we need an enable_if construct for selective compilation
     // MARK: data() -- raw pointer to beginning of underlying storage (pointers or data, depending on dimension)
     FOR_Nx const_pointer_type data() const { return getDataPointer_Nx(); }
     FOR_Nx       pointer_type data()       { return getDataPointer_Nx(); }
-    FOR_N1 const T* data() const { return getDataPointer_N1(); }
-    FOR_N1       T* data()       { return getDataPointer_N1(); }
+    FOR_N1           const T* data() const { return getDataPointer_N1(); }
+    FOR_N1                 T* data()       { return getDataPointer_N1(); }
     
     // MARK: operator[] -- raw data/pointer access; returns pointer N>1, reference for N=1
     FOR_Nx subdim_const_pointer_type operator[] (size_type i) const { return getDataPointer_Nx()[i]; }
     FOR_Nx       subdim_pointer_type operator[] (size_type i)       { return getDataPointer_Nx()[i]; }
-    FOR_N1 const T& operator[] (size_type i) const { return getDataPointer_N1()[i]; }
-    FOR_N1       T& operator[] (size_type i)       { return getDataPointer_N1()[i]; }
+    FOR_N1                  const T& operator[] (size_type i) const { return getDataPointer_N1()[i]; }
+    FOR_N1                        T& operator[] (size_type i)       { return getDataPointer_N1()[i]; }
     
     // MARK: at() -- data/subbuffer access; returns Derived<T,N-1> instance or data
-    FOR_Nx_V decltype(auto) at (size_type dn, I... i) const { return static_cast<const Derived*>(this)->createSubBufferView(dn).at(i...); }
-    FOR_Nx_V decltype(auto) at (size_type dn, I... i)       { return static_cast<Derived*>(this)->createSubBufferView(dn).at(i...); }
-    FOR_Nx decltype(auto) at(size_type dn) const { return static_cast<const Derived*>(this)->createSubBufferView(dn); }
-    FOR_Nx decltype(auto) at (size_type dn)      { return static_cast<Derived*>(this)->createSubBufferView(dn); }
-    FOR_N1 const T& at (size_type i) const { return getDataPointer_N1()[i]; }
-    FOR_N1       T& at (size_type i)       { return getDataPointer_N1()[i]; }
+    FOR_Nx_V decltype(auto) at(size_type dn, I... i) const { return static_cast<const Derived*>(this)->createSubBufferView(dn).at(i...); }
+    FOR_Nx_V decltype(auto) at(size_type dn, I... i)       { return static_cast<      Derived*>(this)->createSubBufferView(dn).at(i...); }
+    FOR_Nx   decltype(auto) at(size_type dn)         const { return static_cast<const Derived*>(this)->createSubBufferView(dn); }
+    FOR_Nx   decltype(auto) at(size_type dn)               { return static_cast<      Derived*>(this)->createSubBufferView(dn); }
+    FOR_N1         const T& at(size_type i)          const { return getDataPointer_N1()[i]; }
+    FOR_N1               T& at(size_type i)                { return getDataPointer_N1()[i]; }
 
 protected:
     // MARK: Virtual functions to be defined by derived classes
@@ -75,6 +79,7 @@ protected:
     virtual       T* getDataPointer_N1() = 0;
 
     // Helper to make interfacing with STL a bit more readable
+    using stl_size_type = typename std::vector<T*>::size_type;
     static constexpr stl_size_type STL(int i) { return static_cast<stl_size_type>(i); }
 };
 

--- a/test/tests/HyperBufferCopyMoveTests.cpp
+++ b/test/tests/HyperBufferCopyMoveTests.cpp
@@ -18,7 +18,8 @@
 
 using namespace slb;
 
-void verifyBuffer(const HyperBufferBase<int, 3>& b)
+template<typename U>
+void verifyBuffer(const U& b)
 {
     REQUIRE (b.dim(0) == 3);
     REQUIRE (b.dim(1) == 2);

--- a/test/tests/HyperBufferTests.cpp
+++ b/test/tests/HyperBufferTests.cpp
@@ -63,24 +63,24 @@ TEST_CASE("HyperBuffer Tests - Construction and Data Access")
     {
         testHyperBuffer1D_size4(buffer);
         buffer[2] = 666;
-        REQUIRE(buffer(2) == 666);
-        buffer(2) = -2;
+        REQUIRE(buffer.at(2) == 666);
+        buffer.at(2) = -2;
         REQUIRE(buffer[2] == -2);
     };
     auto verify2D = [](auto& buffer)
     {
         testHyperBuffer2D_sizes2_4(buffer);
         buffer[1][2] = 666;
-        REQUIRE(buffer(1, 2) == 666);
-        buffer(1, 2) = -2;
+        REQUIRE(buffer.at(1, 2) == 666);
+        buffer.at(1, 2) = -2;
         REQUIRE(buffer[1][2] == -2);
     };
     auto verify3D = [](auto& buffer)
     {
         testHyperBuffer3D_sizes3_3_8(buffer);
         buffer[1][2][6] = 666;
-        REQUIRE(buffer(1, 2, 6) == 666);
-        buffer(1, 2, 6) = -22;
+        REQUIRE(buffer.at(1, 2, 6) == 666);
+        buffer.at(1, 2, 6) = -22;
         REQUIRE(buffer[1][2][6] == -22);
     };
     
@@ -190,14 +190,14 @@ TEST_CASE("HyperBuffer const correctness")
         const auto& constBuffer = buffer;
         
         // verify data read access
-        REQUIRE(buffer(0, 0, 7) == 7);
-        REQUIRE(constBuffer(0, 0, 7) == 7);
+        REQUIRE(buffer.at(0, 0, 7) == 7);
+        REQUIRE(constBuffer.at(0, 0, 7) == 7);
 
         // static checks: verify we can assign to a const, but not to a non-const
-        static_assert(std::is_assignable<const int*&, decltype(constBuffer(0, 1).data())>::value == true, "Can assign to a const");
-        static_assert(std::is_assignable<int*&,       decltype(constBuffer(0, 1).data())>::value == false, "Cannot assign to a non-const");
-        static_assert(std::is_assignable<const int* const*&, decltype(constBuffer(2).data())>::value == true, "Can assign to a const");
-        static_assert(std::is_assignable<int**&,             decltype(constBuffer(2).data())>::value == false, "Cannot assign to a non-const");
+        static_assert(std::is_assignable<const int*&, decltype(constBuffer.at(0, 1).data())>::value == true, "Can assign to a const");
+        static_assert(std::is_assignable<int*&,       decltype(constBuffer.at(0, 1).data())>::value == false, "Cannot assign to a non-const");
+        static_assert(std::is_assignable<const int* const*&, decltype(constBuffer.at(2).data())>::value == true, "Can assign to a const");
+        static_assert(std::is_assignable<int**&,             decltype(constBuffer.at(2).data())>::value == false, "Cannot assign to a non-const");
         static_assert(std::is_assignable<const int*&,  decltype(constBuffer[0][0])>::value == true, "Can assign to a const");
         static_assert(std::is_assignable<int*&,        decltype(constBuffer[0][0])>::value == false, "Cannot assign to a non-const");
         static_assert(std::is_assignable<const int* const*&, decltype(constBuffer[0])>::value == true, "Can assign to a const");
@@ -211,11 +211,11 @@ TEST_CASE("HyperBuffer const correctness")
         static_assert(std::is_assignable<int* const* const*&, decltype(constBuffer.data())>::value == false, "Cannot assign to a non-const");
         static_assert(std::is_assignable<int***&,             decltype(constBuffer.data())>::value == false, "Cannot assign to a non-const");
 
-        static_assert(std::is_trivially_assignable<decltype(constBuffer(0, 0, 7)), int>::value == false, "Cannot write to a const");
+        static_assert(std::is_trivially_assignable<decltype(constBuffer.at(0, 0, 7)), int>::value == false, "Cannot write to a const");
         static_assert(std::is_trivially_assignable<decltype(constBuffer[0][0][7]), int>::value == false, "Cannot write to a const");
         static_assert(std::is_trivially_assignable<decltype(constBuffer.data()[0][0][7]), int>::value == false, "Cannot write to a const");
-        static_assert(std::is_trivially_assignable<decltype(constBuffer(0, 1).data()), int*>::value == false, "Cannot write to a const");
-        static_assert(std::is_trivially_assignable<decltype(constBuffer(1).data()), int*>::value == false, "Cannot write to a const");
+        static_assert(std::is_trivially_assignable<decltype(constBuffer.at(0, 1).data()), int*>::value == false, "Cannot write to a const");
+        static_assert(std::is_trivially_assignable<decltype(constBuffer.at(1).data()), int*>::value == false, "Cannot write to a const");
     };
 
     SECTION("owning") {
@@ -225,9 +225,9 @@ TEST_CASE("HyperBuffer const correctness")
         
         // Explicitly test a 1D owning, because above verify function only checks HyperBufferPreAllocFlat after being reduced to subBuffers
         const HyperBuffer<int, 1> constBuffer1D(4);
-        int a = constBuffer1D(2); (UNUSED(a));
-        static_assert(std::is_trivially_assignable<int&, decltype(constBuffer1D(1))>::value == true, "Can assign to a const");
-        static_assert(std::is_trivially_assignable<decltype(constBuffer1D(1)), int*>::value == false, "Cannot write to a const");
+        int a = constBuffer1D.at(2); (UNUSED(a));
+        static_assert(std::is_trivially_assignable<int&, decltype(constBuffer1D.at(1))>::value == true, "Can assign to a const");
+        static_assert(std::is_trivially_assignable<decltype(constBuffer1D.at(1)), int*>::value == false, "Cannot write to a const");
     }
     SECTION("prealloc flat") {
         int dataRaw1 [3*3*8];
@@ -249,15 +249,15 @@ TEST_CASE("HyperBuffer: sub-buffer construction & operator() access")
     auto verify = [](auto& buffer)
     {
         // RW Access to data via operator()
-        REQUIRE(buffer(0, 1, 5) == 13);
-        buffer(0, 1, 5) = -13;
-        REQUIRE(buffer(0, 1, 5) == -13);
-        buffer(0, 1, 5) = 13; // restore original value
+        REQUIRE(buffer.at(0, 1, 5) == 13);
+        buffer.at(0, 1, 5) = -13;
+        REQUIRE(buffer.at(0, 1, 5) == -13);
+        buffer.at(0, 1, 5) = 13; // restore original value
         
         // N-1 Sub-buffer -> 2D
         int subBufferIndex = GENERATE(0, 1, 2);
         
-        auto subBuffer = buffer(subBufferIndex);
+        auto subBuffer = buffer.at(subBufferIndex);
         REQUIRE(subBuffer.dims() == std::array<int, 2>{buffer.dim(1), buffer.dim(2)});
         int j = 0;
         for (int l=0; l < subBuffer.dim(0); ++l) {
@@ -268,7 +268,7 @@ TEST_CASE("HyperBuffer: sub-buffer construction & operator() access")
         
         // N-2 Sub-buffer -> 1D
         int subBufferIndex2 = 1; // just test one value
-        auto subBuffer2 = buffer(subBufferIndex, subBufferIndex2);
+        auto subBuffer2 = buffer.at(subBufferIndex, subBufferIndex2);
         REQUIRE(subBuffer2.dims() == std::array<int, 1>{buffer.dim(2)});
         j = 0;
         for (int m=0; m < subBuffer2.dim(0); ++m) {
@@ -299,7 +299,7 @@ TEST_CASE("HyperBuffer: sub-buffer construction & operator() access")
         
         { // Creating a subbuffer also does not allocate memory
             ScopedMemorySentinel sentinel;
-            auto subBuffer = buffer(1);
+            auto subBuffer = buffer.at(1);
         }
     }
 }
@@ -316,7 +316,7 @@ TEST_CASE("HyperBuffer: Sub-Buffer Assignmemt")
     bufferData[3] = -4;
     
     //TODO: Sub-Buffer assigment
-    //buffer(0,0) = bufferData;
+    //buffer.at(0,0) = bufferData;
 }
 
 // MARK: - Data Verification

--- a/test/tests/HyperBufferTests.cpp
+++ b/test/tests/HyperBufferTests.cpp
@@ -38,9 +38,9 @@ int** VARNAME[] = { pointerDim1_0, pointerDim1_1, pointerDim1_2 };
 using namespace slb;
 
 // functions to test the integrity of the different variants throught the same API
-template<typename T> void testHyperBuffer1D_size4(HyperBufferBase<T, 1>& buffer);
-template<typename T> void testHyperBuffer2D_sizes2_4(HyperBufferBase<T, 2>& buffer);
-template<typename T> void testHyperBuffer3D_sizes3_3_8(HyperBufferBase<T, 3>& buffer);
+template<typename U> void testHyperBuffer1D_size4(HyperBufferBase<int, 1, U>& buffer);
+template<typename U> void testHyperBuffer2D_sizes2_4(HyperBufferBase<int, 2, U>& buffer);
+template<typename U> void testHyperBuffer3D_sizes3_3_8(HyperBufferBase<int, 3, U>& buffer);
 
 // helper lambda
 static auto fillWith3DSequence = [](auto& buffer)
@@ -321,8 +321,8 @@ TEST_CASE("HyperBuffer: Sub-Buffer Assignmemt")
 
 // MARK: - Data Verification
 
-template<typename T>
-void testHyperBuffer1D_size4(HyperBufferBase<T, 1>& buffer)
+template<typename U>
+void testHyperBuffer1D_size4(HyperBufferBase<int, 1, U>& buffer)
 {
     REQUIRE(buffer.dims() == std::array<int, 1>{4});
     REQUIRE(buffer.dim(0) == 4);
@@ -352,8 +352,8 @@ void testHyperBuffer1D_size4(HyperBufferBase<T, 1>& buffer)
     }
 }
 
-template<typename T>
-void testHyperBuffer2D_sizes2_4(HyperBufferBase<T, 2>& buffer)
+template<typename U>
+void testHyperBuffer2D_sizes2_4(HyperBufferBase<int, 2, U>& buffer)
 {
     REQUIRE(buffer.dims() == std::array<int, 2>{2, 4});
     REQUIRE(buffer.dim(1) == 4);
@@ -386,8 +386,8 @@ void testHyperBuffer2D_sizes2_4(HyperBufferBase<T, 2>& buffer)
     }
 }
 
-template<typename T>
-void testHyperBuffer3D_sizes3_3_8(HyperBufferBase<T, 3>& buffer)
+template<typename U>
+void testHyperBuffer3D_sizes3_3_8(HyperBufferBase<int, 3, U>& buffer)
 {
     REQUIRE(buffer.dims() == std::array<int, 3>{3, 3, 8});
     buffer[0][1][0] = -1;

--- a/test/tests/HyperBufferTests.cpp
+++ b/test/tests/HyperBufferTests.cpp
@@ -38,9 +38,9 @@ int** VARNAME[] = { pointerDim1_0, pointerDim1_1, pointerDim1_2 };
 using namespace slb;
 
 // functions to test the integrity of the different variants throught the same API
-template<typename U> void testHyperBuffer1D_size4(HyperBufferBase<int, 1, U>& buffer);
-template<typename U> void testHyperBuffer2D_sizes2_4(HyperBufferBase<int, 2, U>& buffer);
-template<typename U> void testHyperBuffer3D_sizes3_3_8(HyperBufferBase<int, 3, U>& buffer);
+template<typename U> void testHyperBuffer1D_size4(IHyperBuffer<int, 1, U>& buffer);
+template<typename U> void testHyperBuffer2D_sizes2_4(IHyperBuffer<int, 2, U>& buffer);
+template<typename U> void testHyperBuffer3D_sizes3_3_8(IHyperBuffer<int, 3, U>& buffer);
 
 // helper lambda
 static auto fillWith3DSequence = [](auto& buffer)
@@ -322,7 +322,7 @@ TEST_CASE("HyperBuffer: Sub-Buffer Assignmemt")
 // MARK: - Data Verification
 
 template<typename U>
-void testHyperBuffer1D_size4(HyperBufferBase<int, 1, U>& buffer)
+void testHyperBuffer1D_size4(IHyperBuffer<int, 1, U>& buffer)
 {
     REQUIRE(buffer.dims() == std::array<int, 1>{4});
     REQUIRE(buffer.dim(0) == 4);
@@ -353,7 +353,7 @@ void testHyperBuffer1D_size4(HyperBufferBase<int, 1, U>& buffer)
 }
 
 template<typename U>
-void testHyperBuffer2D_sizes2_4(HyperBufferBase<int, 2, U>& buffer)
+void testHyperBuffer2D_sizes2_4(IHyperBuffer<int, 2, U>& buffer)
 {
     REQUIRE(buffer.dims() == std::array<int, 2>{2, 4});
     REQUIRE(buffer.dim(1) == 4);
@@ -387,7 +387,7 @@ void testHyperBuffer2D_sizes2_4(HyperBufferBase<int, 2, U>& buffer)
 }
 
 template<typename U>
-void testHyperBuffer3D_sizes3_3_8(HyperBufferBase<int, 3, U>& buffer)
+void testHyperBuffer3D_sizes3_3_8(IHyperBuffer<int, 3, U>& buffer)
 {
     REQUIRE(buffer.dims() == std::array<int, 3>{3, 3, 8});
     buffer[0][1][0] = -1;


### PR DESCRIPTION
- Use CRTP to access N-1 creators in derived classes from base class.
- move dimensionExtents member into derived classes (was being duplicated by BufferGeometry)
- this will allow to make HyperBufferBase a pure interface
- use at() instead of operator()
- cosmetics

